### PR TITLE
Changing static user feed to dynamic

### DIFF
--- a/src/GetStream/StreamLaravel/StreamLaravelManager.php
+++ b/src/GetStream/StreamLaravel/StreamLaravelManager.php
@@ -123,14 +123,14 @@ class StreamLaravelManager
     public function activityCreated($instance)
     {
         $activity = $instance->createActivity();
-        $feed = $this->getFeed($this->userFeed, $instance->activityActorId());
+        $feed = $this->getFeed($instance->activityActorMethodName(), $instance->activityActorId());
         $feed->addActivity($activity);
     }
 
     public function activityDeleted($instance)
     {
         $foreignId = $instance->activityForeignId();
-        $feed = $this->getFeed($this->userFeed, $instance->activityActorId());
+        $feed = $this->getFeed($instance->activityActorMethodName(), $instance->activityActorId());
         $feed->removeActivity($foreignId, true);
     }
 }


### PR DESCRIPTION
Changing code to from using a static (hard coded) value of `user_feed` which essentially uses the `user` actor to allow the model binding to use whatever is set in the model under `activityActorMethodName()`. This will allow anyone using a feed other than `user` to have automatic activities created/deleted with those actions.